### PR TITLE
[DBT-73] Support large DBs by requesting only tables defined in manifest

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -1,15 +1,20 @@
-from uuid import uuid4
 import agate
 import re
 import boto3
 from botocore.exceptions import ClientError
-from typing import Optional
+from itertools import chain
 from threading import Lock
+from typing import Dict, Iterator, Optional, Set
+from uuid import uuid4
 
 from dbt.adapters.base import available
+from dbt.adapters.base.impl import GET_CATALOG_MACRO_NAME
+from dbt.adapters.base.relation import InformationSchema
 from dbt.adapters.sql import SQLAdapter
 from dbt.adapters.athena import AthenaConnectionManager
-from dbt.adapters.athena.relation import AthenaRelation
+from dbt.adapters.athena.relation import AthenaRelation, AthenaSchemaSearchMap
+from dbt.contracts.graph.compiled import CompileResultNode
+from dbt.contracts.graph.manifest import Manifest
 from dbt.events import AdapterLogger
 logger = AdapterLogger("Athena")
 
@@ -109,3 +114,36 @@ class AthenaAdapter(SQLAdapter):
         self, column: str, quote_config: Optional[bool]
     ) -> str:
         return super().quote_seed_column(column, False)
+
+    def _get_one_catalog(
+        self,
+        information_schema: InformationSchema,
+        schemas: Dict[str, Optional[Set[str]]],
+        manifest: Manifest,
+    ) -> agate.Table:
+
+        kwargs = {"information_schema": information_schema, "schemas": schemas}
+        table = self.execute_macro(
+            GET_CATALOG_MACRO_NAME,
+            kwargs=kwargs,
+            # pass in the full manifest so we get any local project
+            # overrides
+            manifest=manifest,
+        )
+
+        results = self._catalog_filter_table(table, manifest)
+        return results
+
+
+    def _get_catalog_schemas(self, manifest: Manifest) -> AthenaSchemaSearchMap:
+        info_schema_name_map = AthenaSchemaSearchMap()
+        nodes: Iterator[CompileResultNode] = chain(
+            [node for node in manifest.nodes.values() if (
+                node.is_relational and not node.is_ephemeral_model
+            )],
+            manifest.sources.values(),
+        )
+        for node in nodes:
+            relation = self.Relation.create_from(self.config, node)
+            info_schema_name_map.add(relation)
+        return info_schema_name_map

--- a/dbt/adapters/athena/relation.py
+++ b/dbt/adapters/athena/relation.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
+from typing import Dict, Optional, Set 
 
-from dbt.adapters.base.relation import BaseRelation, Policy
+from dbt.adapters.base.relation import BaseRelation, InformationSchema, Policy
 
 
 @dataclass
@@ -14,3 +15,20 @@ class AthenaIncludePolicy(Policy):
 class AthenaRelation(BaseRelation):
     quote_character: str = ""
     include_policy: Policy = AthenaIncludePolicy()
+
+class AthenaSchemaSearchMap(Dict[InformationSchema, Dict[str, Set[Optional[str]]]]):
+    """A utility class to keep track of what information_schema tables to
+    search for what schemas and relations. The schema and relation values are all
+    lowercased to avoid duplication.
+    """
+    def add(self, relation: AthenaRelation):
+        key = relation.information_schema_only()
+        if key not in self:
+            self[key] = {}
+        schema: Optional[str] = None
+        if relation.schema is not None:
+            schema = relation.schema.lower()
+            relation_name = relation.name.lower()
+            if schema not in self[key]:
+                self[key][schema] = set()
+            self[key][schema].add(relation_name)


### PR DESCRIPTION
# [DBT-73](https://jira.fundingcircle.com/browse/DBT-73)

## Overview
Currently the athena__get_catalog macro query hangs indefinitely when trying to generate docs for a database with more than 100 tables, these changes fix the issue by specifying which tables to fetch per each database and batches to a maximum of 100 tables.

## What's changed
It overrides the default `BaseAdapter._get_catalog_schemas()` function with a custom `AthenaAdapter._get_catalog_schemas()`, which instead of using `SchemaSearchMap` now uses a custom `AthenaSchemaSearchMap`.
The `SchemaSearchMap.add()` only returns a dictionary with values being a set of database names, the new `AthenaSchemaSearchMap.add()` returns a dictionary of dictionaries, where each dictionary key is a database name and the value is a set of the tables in the database.
`_get_one_catalog` is also updated with the correct typing.

Using the new `AthenaSchemaSearchMap` the `athena__get_catalog` macro now batches the queries to do a maximum select of 100 tables per database per each union.