### PR TITLE
[DBT-97] Override list_relations_without_caching using boto3

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 from dbt.adapters.base import available
 from dbt.adapters.base.impl import GET_CATALOG_MACRO_NAME
-from dbt.adapters.base.relation import InformationSchema
+from dbt.adapters.base.relation import BaseRelation, InformationSchema
 from dbt.adapters.sql import SQLAdapter
 from dbt.adapters.athena import AthenaConnectionManager
 from dbt.adapters.athena.relation import AthenaRelation, AthenaSchemaSearchMap
@@ -159,7 +159,7 @@ class AthenaAdapter(SQLAdapter):
 
     def list_relations_without_caching(
         self, schema_relation: AthenaRelation,
-    ) -> List[AthenaRelation]:
+    ) -> List[BaseRelation]:
         catalog_id = None
         if schema_relation.database.lower() != 'awsdatacatalog':
             data_catalog = self._get_data_catalog(schema_relation.database.lower())


### PR DESCRIPTION
Similar to the issue with `dbt docs`. 

Whenever you do a `dbt run`, dbt has to do an initial 'data gathering' query to the information schema to get a list of all relations within the database you are working on. This query is found in the macro (athena__list_relations_without_caching)[https://github.com/FundingCircle/dbt-athena/blob/master/dbt/include/athena/macros/adapters/metadata.sql#L104]. This has a similar issue to the one we tackled in `dbt docs` whereby the query fails if the database has 100+ tables. 

Rather than trying to adjust the query to do batching, which is:
a) trickier because we don't know the list of table names upfront (we we did with `dbt docs` since it was just the list of sources
b) slow as hell, when you get up to 99 tables it takes a long time to make that information_schema query

I changed it to use boto3 to get the necessary data instead. 

The only issue is to do with glue catalogs. To get able to get the list of relations through boto3 this way your tables have to be in Glue (obviously) - but in Athena you can of course have external Data Sources (such as federated queries or a cross-account glue catalog). It's not super obvious how this will behave with the code I've written, and I don't want to spend ages testing all these scenarios right now.

What I have at the moment is a check to see if the Data Catalog is a GLUE type (i.e. cross account access). If so, we have to pass the CatalogId. If not (e.g. a federated data source?) I'm just passing back to the original SQL. I think this is a suitable solution for now.

On another note, we could change the `dbt docs` code to use this approach too and it will be a lot faster than querying the information schema - although the same issue with `awsgluecatalog` applies.

