### PR TITLE
[DBT-115] Include database and fix list_relations_without_caching bug

### DIFF
--- a/dbt/adapters/athena/relation.py
+++ b/dbt/adapters/athena/relation.py
@@ -6,7 +6,7 @@ from dbt.adapters.base.relation import BaseRelation, InformationSchema, Policy
 
 @dataclass
 class AthenaIncludePolicy(Policy):
-    database: bool = False
+    database: bool = True
     schema: bool = True
     identifier: bool = True
 
@@ -15,6 +15,7 @@ class AthenaIncludePolicy(Policy):
 class AthenaRelation(BaseRelation):
     quote_character: str = ""
     include_policy: Policy = AthenaIncludePolicy()
+
 
 class AthenaSchemaSearchMap(Dict[InformationSchema, Dict[str, Set[Optional[str]]]]):
     """A utility class to keep track of what information_schema tables to


### PR DESCRIPTION
- set `database: bool = True` so the Glue catalog is included in the query (for cross-account setup)
- Wrapped the paginator in `list_relations_without_caching` inside a try/except as this will currently fail if the database doesn't exist entirely (compared to the original SQL based implementation where this will not fail). I will also need to update this in the open-source PR